### PR TITLE
Block SyncAdapter.onPerformSync() until the javascript task is executed

### DIFF
--- a/android/src/main/java/com/fnp/reactnativesyncadapter/HeadlessService.java
+++ b/android/src/main/java/com/fnp/reactnativesyncadapter/HeadlessService.java
@@ -3,16 +3,58 @@ package com.fnp.reactnativesyncadapter;
 import android.app.ActivityManager;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Binder;
+import android.os.IBinder;
+import android.support.annotation.Nullable;
 
 import com.facebook.react.HeadlessJsTaskService;
 import com.facebook.react.jstasks.HeadlessJsTaskConfig;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class HeadlessService extends HeadlessJsTaskService {
 
     private static final String TASK_ID = "TASK_SYNC_ADAPTER";
 
+    private final IBinder mBinder = new LocalBinder();
+    private List<Callback> mCallbacks = new ArrayList<>();
+
+    public class LocalBinder extends Binder {
+        HeadlessService getService() {
+            return HeadlessService.this;
+        }
+    }
+
+    public interface Callback {
+        void onTaskCompletion();
+    }
+
+    @Override
+    public @Nullable
+    IBinder onBind(Intent intent) {
+        return mBinder;
+    }
+
+    public void notifyOnTaskCompletion(Callback cb) {
+        mCallbacks.add(cb);
+    }
+
+    @Override
+    public void onHeadlessJsTaskFinish(int taskId) {
+        super.onHeadlessJsTaskFinish(taskId);
+        for (Callback cb : mCallbacks) {
+            cb.onTaskCompletion();
+        }
+        mCallbacks.clear();
+    }
+
+    public void startHeadlessTask(Intent intent) {
+        HeadlessJsTaskConfig taskConfig = getTaskConfig(intent);
+        if (taskConfig != null) {
+            startTask(taskConfig);
+        }
+    }
     @Override
     protected HeadlessJsTaskConfig getTaskConfig(Intent intent) {
         boolean allowForeground = Boolean.valueOf(getString(R.string.rnsb_allow_foreground));


### PR DESCRIPTION
Block the sync if the task is user visible.

This way when a manual sync is requested from account settings, an
indication that the sync is still happening will be shown to the user,
thus making a better user experience.