### PR TITLE
HeadlessJsTaskConfig issue fixed

### DIFF
--- a/android/src/main/java/com/fnp/reactnativesyncadapter/HeadlessService.java
+++ b/android/src/main/java/com/fnp/reactnativesyncadapter/HeadlessService.java
@@ -6,6 +6,8 @@ import android.content.Intent;
 
 import com.facebook.react.HeadlessJsTaskService;
 import com.facebook.react.jstasks.HeadlessJsTaskConfig;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.Arguments;
 
 import java.util.List;
 
@@ -16,11 +18,12 @@ public class HeadlessService extends HeadlessJsTaskService {
     @Override
     protected HeadlessJsTaskConfig getTaskConfig(Intent intent) {
         boolean allowForeground = Boolean.valueOf(getString(R.string.rnsb_allow_foreground));
+        WritableMap data = Arguments.createMap();
 
         if(allowForeground || !isAppOnForeground(this)) {
             return new HeadlessJsTaskConfig(
                     TASK_ID,
-                    null,
+                    data,
                     Long.valueOf(getString(R.string.rnsb_default_timeout)),
                     allowForeground);
         }


### PR DESCRIPTION
https://github.com/ferrannp/react-native-sync-adapter/issues/21

[SO answer](https://stackoverflow.com/a/59686204/4115953)

In `react-native: 0.60.2` giving following error:

```
java.lang.NullPointerException: Attempt to invoke interface method 'com.facebook.react.bridge.WritableMap com.facebook.react.bridge.WritableMap.copy()' on a null object reference
	at com.facebook.react.jstasks.HeadlessJsTaskConfig.<init>(HeadlessJsTaskConfig.java:88)
	at com.facebook.react.jstasks.HeadlessJsTaskContext.startTask(HeadlessJsTaskContext.java:106)
	at com.facebook.react.jstasks.HeadlessJsTaskContext.startTask(HeadlessJsTaskContext.java:84)
	at com.facebook.react.HeadlessJsTaskService$2.run(HeadlessJsTaskService.java:123)
	at android.os.Handler.handleCallback(Handler.java:739)
	at android.os.Handler.dispatchMessage(Handler.java:95)
	at android.os.Looper.loop(Looper.java:160)
	at android.app.ActivityThread.main(ActivityThread.java:5541)
	at java.lang.reflect.Method.invoke(Native Method)
	at java.lang.reflect.Method.invoke(Method.java:372)
	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:964)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:759)
```
